### PR TITLE
Fix: RL1M-259 stompInterceptor에도 Authorization 포맷 변경 반영

### DIFF
--- a/src/api/config/stompInterceptor.ts
+++ b/src/api/config/stompInterceptor.ts
@@ -1,11 +1,16 @@
-import { Client } from "@stomp/stompjs";
-import { getJwt } from "./setToken";
+import { Client } from '@stomp/stompjs';
+import { getJwt } from './setToken';
 
 export const stompClient = (): Client => {
+  const authorization = getJwt();
+  if (!authorization) {
+    throw new Error('Authorization is not set');
+  }
+
   const client = new Client({
     brokerURL: `${import.meta.env.VITE_SERVER_URL}/connection`,
     connectHeaders: {
-      Authorization: `Bearer ${getJwt()}`,
+      Authorization: authorization,
     },
     debug: (str) => {
       console.log(str);
@@ -13,10 +18,10 @@ export const stompClient = (): Client => {
   });
 
   client.onStompError = (frame) => {
-    console.error("STOMP error:", frame.headers.message);
+    console.error('STOMP error:', frame.headers.message);
   };
   client.onDisconnect = () => {
-    console.log("Disconnected from WebSocket");
+    console.log('Disconnected from WebSocket');
   };
 
   return client;


### PR DESCRIPTION
## Description

- [Jira Ticket: RL1M-259](https://relay-letter.atlassian.net/browse/RL1M-259)
- Access Token 포맷을 변경해두고 WebSocket 쪽 반영을 빼먹었습니다.

## Changes

- [x] localStorage에 저장하는 Access Token 포맷 변경 반영 (Bearer prefix를 포함해 저장하는 것으로 변경 )
