### PR TITLE
Fix: RL1M-269 Home에서 비로그인 상태인 경우 인증이 필요한 웹소켓 호출하지 않게 해서 빈 페이지가 보이지 않게

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { quitLetterWs } from '../../api/service/WsService';
 import { SessionLogger } from '../../utils';
+import { accessTokenRepository } from '../../api/config/AccessTokenRepository';
 
 const logger = new SessionLogger('home');
 
@@ -56,8 +57,10 @@ export const HomePage = () => {
     }
     if (localStorage.getItem('letterId')) {
       const letterId = Number(localStorage.getItem('letterId'));
-      quitLetterWs(letterId);
-      logger.debug('소켓퇴장처리');
+      if (accessTokenRepository.isLoggedIn()) {
+        quitLetterWs(letterId);
+        logger.debug('소켓퇴장처리');
+      }
       localStorage.removeItem('letterId');
     }
     localStorage.removeItem('receiver');


### PR DESCRIPTION
## Description

- [Jira Ticket: RL1M-269](https://relay-letter.atlassian.net/browse/RL1M-269)
- 현재 모든 웹소켓 연결은 인증이 필요한 Endpoint인데, Home은 비로그인 사용자도 접근할 수 있어서 오류가 발생

## Changes

- [x] Home에서 사용하는 웹소켓 연결인 편지 작성 퇴장 로직을 AccessToken이 없으면 실행하지 않게 변경
