### PR TITLE
Fix: RL1M-277 lint command가 config에 따라 동작하지 않던 점 수정

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,32 +6,34 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 import prettierRecommended from 'eslint-plugin-prettier/recommended';
 
-export default [
-  ...tseslint.config({
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ['**/*.{ts,tsx}'],
-    ignores: ['dist'],
-    languageOptions: {
-      ecmaVersion: 2020,
-      globals: globals.browser,
-    },
-    plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
-      react,
-    },
-    rules: {
-      ...reactHooks.configs.recommended.rules,
-      'react/react-in-tsx-scope': 'off',
-      'react/react-in-jsx-scope': 'off',
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
-      'no-multiple-empty-lines': 'error',
-      'no-unused-vars': 'error',
-      eqeqeq: 'error',
-    },
-  }),
-  prettierRecommended,
-];
+// NOTE: tseslint.config를 [] 에 감싸서 내보내면 CLI가 제대로 동작하지 않음
+export default tseslint.config({
+  extends: [
+    js.configs.recommended,
+    ...tseslint.configs.recommended,
+    prettierRecommended,
+  ],
+  files: ['**/*.{ts,tsx}'],
+  ignores: ['dist', 'node_modules', 'public'],
+  languageOptions: {
+    ecmaVersion: 2020,
+    globals: globals.browser,
+  },
+  plugins: {
+    'react-hooks': reactHooks,
+    'react-refresh': reactRefresh,
+    react,
+  },
+  rules: {
+    ...reactHooks.configs.recommended.rules,
+    'react/react-in-tsx-scope': 'off',
+    'react/react-in-jsx-scope': 'off',
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+    'no-multiple-empty-lines': 'error',
+    'no-unused-vars': 'error',
+    eqeqeq: 'error',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint --config ./eslint.config.js"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.3.0",


### PR DESCRIPTION
## Description

- [Jira Ticket: RL1M-277](https://relay-letter.atlassian.net/browse/RL1M-277)
- npm run lint로 CLI로 실행 시 config를 읽지 않고 `dist` 까지 린팅하거나, tsx 문법 인식을 못하는 등 현상 수정
- 원인은 특이하게도 `tseslint.config()`를 export하느냐, `[]`에 넣느냐의 차이인데, 왜 그런지는 모르는 상황

## Changes

- [x] package.json - lint 명령 시 config 참조하도록 변경
- [x] eslint.config.js - export 하는 방식을 `[]` -> `tseslint`로 변경