### PR TITLE
Fix: RL1M-280 localStorage에 userId가 없어지는 문제 해결을 위해 mypage API 조회 시에도 설정하게

### DIFF
--- a/src/api/config/kakaoLogin.ts
+++ b/src/api/config/kakaoLogin.ts
@@ -1,6 +1,6 @@
 import { requestKakaoAuthentication } from '../service/AuthService';
 import { accessTokenRepository } from './AccessTokenRepository';
-import { setUserIdOnLocalStorage } from './setToken';
+import { setUserIdFromAccessToken } from './setToken';
 
 export const kakaoLogin = async (kakaoSocialLoginCode: string) => {
   const { accessToken } =
@@ -8,5 +8,5 @@ export const kakaoLogin = async (kakaoSocialLoginCode: string) => {
   accessTokenRepository.onLogin(accessToken);
 
   // NOTE: 현재 로컬스토리지로 유저id 공유 중이어서 아직 필요...
-  setUserIdOnLocalStorage(accessToken);
+  setUserIdFromAccessToken(accessToken);
 };

--- a/src/api/config/setToken.ts
+++ b/src/api/config/setToken.ts
@@ -21,7 +21,11 @@ interface jwtType {
 }
 
 // 세션에 유저 아이디 저장하기
-export const setUserIdOnLocalStorage = (jwt: string) => {
+export const setUserIdFromAccessToken = (jwt: string) => {
   const userId: jwtType = jwtDecode(jwt);
   window.localStorage.setItem('userId', userId.sub);
+};
+
+export const setUserId = (userId: number | string) => {
+  window.localStorage.setItem('userId', userId.toString());
 };

--- a/src/api/service/MemberService.ts
+++ b/src/api/service/MemberService.ts
@@ -1,4 +1,5 @@
 import { ApiResponse, api } from '../config/api';
+import { setUserId } from '../config/setToken';
 import {
   LetterCountsGetResponse,
   LetterboxDeleteResponse,
@@ -20,6 +21,10 @@ export async function getLetterCounts(): Promise<LetterCountsGetResponse> {
 export async function getMyPage(): Promise<MypageGetResponse> {
   const response: ApiResponse<MypageGetResponse> =
     await api.get(`api/member/mypage`);
+
+  // FIXME: 무슨 이유에서인지, localStorage에 없는 경우가 발생..!
+  setUserId(response.data.data.memberId);
+
   return response.data.data;
 }
 

--- a/src/components/accountPage/Logout.tsx
+++ b/src/components/accountPage/Logout.tsx
@@ -17,7 +17,6 @@ export const Logout = ({ setPopup }: Props) => {
 
   const handleLogout = async () => {
     await postLogout();
-    localStorage.removeItem('jwt');
     localStorage.clear();
     navigate('/', { replace: true });
   };


### PR DESCRIPTION
## Description

- [Jira Ticket: RL1M-280](https://relay-letter.atlassian.net/browse/RL1M-280)
- 로그인할 때만 userId를 localstorage에 저장하는데, 직접 Application 탭에서 날리는 등의 작업을 하면 localStorage에 userId가 없어서 관련 로직이 망가짐

## Changes

- [x] mypage API 호출 시마다 일단 보관하게 변경

### Screenshots

- Application 탭에서 다 날려도 복구됨을 확인

<img width="600" alt="image" src="https://github.com/user-attachments/assets/54f92aa1-4776-4c92-8529-d46efa905bdb" />
