### PR TITLE
Fix: 공유 링크 receiverName 인코딩 문제 해결

### DIFF
--- a/src/components/letterboxPage/Created_Modal.tsx
+++ b/src/components/letterboxPage/Created_Modal.tsx
@@ -87,11 +87,12 @@ export const Created_Modal = ({
   const handleShare = async () => {
     const letterId = encodeId;
     if (letterInfo) {
+      const encodedReceiverName = encodeURIComponent(letterInfo.receiverName);
       const shareText = `To. ${letterInfo.receiverName}\n${letterInfo.title}\nFrom. ${letterInfo.participantNames
         .map((element) => element)
         .join(', ')}`;
       if (!isMobile) {
-        const shareTextPc = `${import.meta.env.VITE_FRONT_URL}/receive/${letterId}?to=${letterInfo.receiverName}`;
+        const shareTextPc = `${import.meta.env.VITE_FRONT_URL}/receive/${letterId}?to=${encodedReceiverName}`;
         if (
           navigator.clipboard &&
           typeof navigator.clipboard.writeText === 'function'
@@ -113,7 +114,7 @@ export const Created_Modal = ({
         try {
           await navigator.share({
             text: shareText,
-            url: `${import.meta.env.VITE_FRONT_URL}/receive/${letterId}?to=${letterInfo.receiverName}`,
+            url: `${import.meta.env.VITE_FRONT_URL}/receive/${letterId}?to=${encodedReceiverName}`,
           });
           logger.debug('공유 성공');
         } catch (e) {

--- a/src/components/sharePage/ShareLetter.tsx
+++ b/src/components/sharePage/ShareLetter.tsx
@@ -145,12 +145,14 @@ export const ShareLetter = () => {
 
   const createShare = async () => {
     if (letterInfo) {
+      const encodedReceiverName = encodeURIComponent(letterInfo.receiverName);
+
       const shareText = `To. ${letterInfo.receiverName}\n${letterInfo.title}\nFrom. ${letterInfo.participantNames
         .map((element) => element)
         .join(', ')}`;
 
       if (!isMobile) {
-        const shareTextPc = `${shareText}\n${import.meta.env.VITE_FRONT_URL}/receive/${letterId}?to=${letterInfo.receiverName}`;
+        const shareTextPc = `${shareText}\n${import.meta.env.VITE_FRONT_URL}/receive/${letterId}?to=${encodedReceiverName}`;
         if (
           navigator.clipboard &&
           typeof navigator.clipboard.writeText === 'function'
@@ -171,7 +173,7 @@ export const ShareLetter = () => {
         try {
           await navigator.share({
             text: shareText,
-            url: `${import.meta.env.VITE_FRONT_URL}/receive/${letterId}?to=${letterInfo.receiverName}`,
+            url: `${import.meta.env.VITE_FRONT_URL}/receive/${letterId}?to=${encodedReceiverName}`,
           });
           logger.debug('공유 성공');
         } catch (e) {


### PR DESCRIPTION
## Description

- [Jira Ticket: RL1M-](https://relay-letter.atlassian.net/browse/RL1M-290)

## Changes

- [x] 완성된 편지 링크 공유 시 receiverName 인코딩하여 생성
`const encodedReceiverName = encodeURIComponent(letterInfo.receiverName);`

### Screenshots
