### PR TITLE
Fix: RL1M-288 편지 작성 과정에서 뒤로가기/앞으로가기 할 수 없게 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,17 +40,20 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/login/redirect" element={<LoginRedirectPage />} />
-          <Route path="/write/:letterId" element={<WritePage />} />
           <Route path="/receive/:letterId" element={<ReceivePage />} />
           <Route
             path="/receive/letter/:letterId"
             element={<ReceiveLetterPage />}
           />
-          <Route path="/share/:letterId" element={<ShareLetterPage />} />
+
+          {/* TODO: 편지 작성 퍼널로 변경 */}
           <Route path="/create" element={<CreatePage />} />
           <Route path="/invite" element={<InvitePage />} />
           <Route path="/join/:letterId" element={<JoinPage />} />
           <Route path="/connection" element={<ConnectionPage />} />
+          <Route path="/write/:letterId" element={<WritePage />} />
+          <Route path="/share/:letterId" element={<ShareLetterPage />} />
+
           <Route path="/account" element={<AccountPage />} />
           <Route path="/letterbox" element={<LetterBoxPage />} />
           <Route path="/loading" element={<LoadingPage />} />

--- a/src/components/InvitePage/Delete/DeleteConfirm.tsx
+++ b/src/components/InvitePage/Delete/DeleteConfirm.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -11,41 +9,7 @@ export const DeleteConfirm = () => {
   const handleButton = () => {
     navigate('/', { replace: true });
   };
-  const handleGoBack = () => {
-    navigate('/', { replace: true });
-  };
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
 
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, []);
-
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [navigate]);
-
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [location]);
   return (
     <BackGround>
       <Container>

--- a/src/components/InvitePage/Invite.tsx
+++ b/src/components/InvitePage/Invite.tsx
@@ -43,43 +43,6 @@ export const Invite = () => {
   const [, setLoad] = useState<boolean>(true);
   const [loadstatus, setLoadstatus] = useState<boolean>(true);
 
-  const handleGoBack = () => {
-    navigate('/', { replace: true });
-  };
-
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, []);
-
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [navigate]);
-
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [location]);
-
   const fetchParticipants = async () => {
     setLoad(true);
     const data = await getParticipants(letterId);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './usePreventBack';

--- a/src/hooks/usePreventBack.ts
+++ b/src/hooks/usePreventBack.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+export const usePreventBack = () => {
+  useEffect(() => {
+    const preventGoBack = () => {
+      window.history.go(1); // STEP 2. 뒤로가기 시 다시 앞으로 이동
+    };
+
+    const preventUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    // STEP 1. 페이지 방문 시 동일 history를 복제해서 추가하여 뒤로 가도 동일 페이지가 유지되게
+    window.history.pushState(
+      {
+        ...window.history.state,
+      },
+      '',
+      window.location.href,
+    );
+    window.addEventListener('popstate', preventGoBack);
+    window.addEventListener('beforeunload', preventUnload);
+
+    return () => {
+      window.removeEventListener('popstate', preventGoBack);
+      window.removeEventListener('beforeunload', preventUnload);
+    };
+  }, []);
+};

--- a/src/pages/connect/ConnectionPage.tsx
+++ b/src/pages/connect/ConnectionPage.tsx
@@ -1,23 +1,9 @@
-import { useEffect } from 'react';
-
-import { useNavigate } from 'react-router-dom';
-
 import { Connection } from '../../components/connectionPage/Connection';
+import { usePreventBack } from '../../hooks';
 
 export const ConnectionPage = () => {
-  const navigate = useNavigate();
-  const handleGoBack = () => {
-    navigate('/');
-  };
-  useEffect(() => {
-    history.pushState(null, '', window.location.href);
+  usePreventBack();
 
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, []);
   return (
     <div>
       <Connection />

--- a/src/pages/create/CreatePage.tsx
+++ b/src/pages/create/CreatePage.tsx
@@ -1,15 +1,8 @@
 import { useEffect } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import { Create } from '../../components/createPage/Create';
 
 export const CreatePage = () => {
-  const navigate = useNavigate();
-  const handleGoBack = () => {
-    navigate('/');
-  };
-
   useEffect(() => {
     if (localStorage.getItem('load')) {
       localStorage.removeItem('load');
@@ -19,15 +12,8 @@ export const CreatePage = () => {
       localStorage.removeItem('letterId');
       localStorage.removeItem('guideOpen');
     }
-
-    history.pushState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
   }, []);
+
   return (
     <div>
       <Create />

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import { accessTokenRepository } from '../../api/config/AccessTokenRepository';
 import { quitLetterWs } from '../../api/service/WsService';
 import { Home } from '../../components/homePage/Home';
@@ -10,45 +8,6 @@ import { SessionLogger } from '../../utils';
 const logger = new SessionLogger('home');
 
 export const HomePage = () => {
-  const navigate = useNavigate();
-
-  const handleGoBack = () => {
-    navigate('/', { replace: true });
-  };
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, []);
-
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [navigate]);
-
-  useEffect(() => {
-    // 현재 페이지를 히스토리에 추가하여 뒤로가기 할 수 없게 함
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [location]);
-
   useEffect(() => {
     if (localStorage.getItem('load')) {
       localStorage.removeItem('load');

--- a/src/pages/invite/InvitePage.tsx
+++ b/src/pages/invite/InvitePage.tsx
@@ -1,6 +1,9 @@
 import { Invite } from '../../components/InvitePage/Invite';
+import { usePreventBack } from '../../hooks';
 
 export const InvitePage = () => {
+  usePreventBack();
+
   return (
     <div>
       <Invite />

--- a/src/pages/invite/LoadingPage.tsx
+++ b/src/pages/invite/LoadingPage.tsx
@@ -1,48 +1,6 @@
-import { useEffect } from 'react';
-
-import { useNavigate } from 'react-router-dom';
-
 import { Loading } from '../../components/InvitePage/Loading';
 
 export const LoadingPage = () => {
-  const navigate = useNavigate();
-
-  const handleGoBack = () => {
-    navigate('/', { replace: true });
-  };
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, []);
-
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [navigate]);
-
-  useEffect(() => {
-    window.history.pushState(null, '', window.location.href);
-    window.history.replaceState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [location]);
-
   return (
     <div>
       <Loading />

--- a/src/pages/join/JoinPage.tsx
+++ b/src/pages/join/JoinPage.tsx
@@ -1,6 +1,9 @@
 import { Join } from '../../components/joinPage/Join';
+import { usePreventBack } from '../../hooks';
 
 export const JoinPage = () => {
+  usePreventBack();
+
   return (
     <div>
       <Join />

--- a/src/pages/letterbox/LetterBoxPage.tsx
+++ b/src/pages/letterbox/LetterBoxPage.tsx
@@ -1,27 +1,6 @@
-import { useEffect } from 'react';
-
-import { useNavigate } from 'react-router-dom';
-
 import { LetterBox } from '../../components/letterboxPage/LetterBox';
 
 export const LetterBoxPage = () => {
-  const navigate = useNavigate();
-
-  const handleGoBack = () => {
-    navigate('/', { replace: true });
-  };
-
-  useEffect(() => {
-    // 현재 페이지를 히스토리에 추가하여 뒤로가기 할 수 없게 함
-    window.history.pushState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, [location]);
-
   return (
     <div>
       <LetterBox />

--- a/src/pages/receive/ReceiveLetterPage.tsx
+++ b/src/pages/receive/ReceiveLetterPage.tsx
@@ -1,25 +1,6 @@
-import { useEffect } from 'react';
-
-import { useNavigate } from 'react-router-dom';
-
 import { ReceiveLetter } from '../../components/receivePage/ReceiveLetter';
 
 export const ReceiveLetterPage = () => {
-  const navigate = useNavigate();
-
-  const handleGoBack = () => {
-    navigate('/');
-  };
-  useEffect(() => {
-    history.pushState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, []);
-
   return (
     <div>
       <ReceiveLetter />

--- a/src/pages/receive/ReceivePage.tsx
+++ b/src/pages/receive/ReceivePage.tsx
@@ -1,25 +1,6 @@
-import { useEffect } from 'react';
-
-import { useNavigate } from 'react-router-dom';
-
 import Receive from '../../components/receivePage/Receive';
 
 export const ReceivePage = () => {
-  const navigate = useNavigate();
-
-  const handleGoBack = () => {
-    navigate('/');
-  };
-  useEffect(() => {
-    history.pushState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, []);
-
   return (
     <div>
       <Receive />

--- a/src/pages/share/SharePage.tsx
+++ b/src/pages/share/SharePage.tsx
@@ -1,24 +1,8 @@
-import { useEffect } from 'react';
-
-import { useNavigate } from 'react-router-dom';
-
 import { ShareLetter } from '../../components/sharePage/ShareLetter';
+import { usePreventBack } from '../../hooks';
 
 export const ShareLetterPage = () => {
-  const navigate = useNavigate();
-
-  const handleGoBack = () => {
-    navigate('/');
-  };
-  useEffect(() => {
-    history.pushState(null, '', window.location.href);
-
-    window.addEventListener('popstate', handleGoBack);
-
-    return () => {
-      window.removeEventListener('popstate', handleGoBack);
-    };
-  }, []);
+  usePreventBack();
 
   return (
     <div>

--- a/src/pages/write/WritePage.tsx
+++ b/src/pages/write/WritePage.tsx
@@ -9,8 +9,11 @@ import { LetterStartInfoGetResponse } from '../../api/model/LetterModel';
 import { getLetterStartInfo } from '../../api/service/LetterService';
 import { Write } from '../../components/writePage/Write';
 import { WriteMainModal } from '../../components/writePage/writeMainModal/WriteMainModal';
+import { usePreventBack } from '../../hooks';
 
 export const WritePage = () => {
+  usePreventBack();
+
   const { letterId } = useParams();
   const [letterNumId] = useState(decodeLetterId(String(letterId)));
   // 불러온 편지 정보


### PR DESCRIPTION
## Description

- [Jira Ticket: RL1M-288](https://relay-letter.atlassian.net/browse/RL1M-288)
- 참고: 브라우저에서 페이지 방문 후 아무런 인터렉션이 없으면 `popstate` 핸들러가 호출되지 않습니다(fallback으로 `beforeunload`가 호출 됩니다)
- https://stackoverflow.com/questions/57339098/chrome-popstate-not-firing-on-back-button-if-no-user-interaction

## Changes

- [x] 기존에 뒤로 가기 시 `/`으로 보내는 코드 제거
- [x] 신규 뒤로 가기 방지 훅 추가 - 동일 history를 1개 더 생성하고, 앞으로 바로 가게 하는 방식

### Screenshots

https://github.com/user-attachments/assets/9591d733-46f8-415b-8922-8c2e41c18eae
