### PR TITLE
Fix: RL1M-318 Header 위치 변경, setVh 호출 추가

### DIFF
--- a/src/components/writePage/writeElement/WriteElement.tsx
+++ b/src/components/writePage/writeElement/WriteElement.tsx
@@ -127,40 +127,6 @@ export const WriteElement = ({
     checkInitialDevice();
   }, []);
 
-  /*useEffect(() => {
-    const handleResize = () => {
-      let keyboardHeight = 0;
-      if (window.visualViewport) {
-        keyboardHeight = window.innerHeight - window.visualViewport.height;
-      } else {
-        keyboardHeight =
-          window.innerHeight - document.documentElement.clientHeight;
-      }
-
-      if (keyboardHeight < 0) {
-        keyboardHeight = Math.max(0, keyboardHeight); // 음수는 0으로 처리
-      }
-
-      if (keyboardHeight > 0) {
-        if (window.innerWidth < 850) {
-          setBottomOffset(keyboardHeight); // 키보드 높이가 0 이상인 경우만 설정
-        } else {
-          setBottomOffset(0);
-        }
-      } else {
-        setBottomOffset(0); // 키보드 높이를 0으로 설정
-      }
-    };
-
-    window.visualViewport?.addEventListener('resize', handleResize);
-
-    handleResize();
-
-    return () => {
-      window.visualViewport?.removeEventListener('resize', handleResize);
-    };
-  }, []);*/
-
   useEffect(() => {
     const setVh = () => {
       const vh = window.innerHeight * 0.01;
@@ -183,6 +149,8 @@ export const WriteElement = ({
       } else {
         setBottomOffset(0);
       }
+
+      setVh();
     };
 
     setVh();
@@ -210,9 +178,11 @@ export const WriteElement = ({
         isMobile={mobile}
         style={{
           //paddingBottom: mobile ? `10px` : '0px',
-          height: mobile
+          /*height: mobile
             ? `calc(var(--vh, 1vh) * 100 - ${bottomOffset}px)`
-            : undefined,
+            : undefined,*/
+          height: `calc(var(--vh, 1vh) * 100 - ${bottomOffset}px)`,
+          bottom: `${bottomOffset - 2}px`,
         }}
       >
         <PhotoDiv isMobile={mobile}>

--- a/src/components/writePage/writeElement/WriteElement.tsx
+++ b/src/components/writePage/writeElement/WriteElement.tsx
@@ -199,6 +199,13 @@ export const WriteElement = ({
 
   return (
     <Container isMobile={mobile}>
+      <Header isMobile={mobile}>
+        <ClockText>
+          <ClockIcon src="/assets/write/clock.svg" />
+          {Math.max(0, Math.floor(progressTime))}초
+        </ClockText>
+        <CloseBtn onClick={handleExit} src="/assets/btn_close.svg" />
+      </Header>
       <Content
         isMobile={mobile}
         style={{
@@ -208,13 +215,6 @@ export const WriteElement = ({
             : undefined,
         }}
       >
-        <Header isMobile={mobile}>
-          <ClockText>
-            <ClockIcon src="/assets/write/clock.svg" />
-            {Math.max(0, Math.floor(progressTime))}초
-          </ClockText>
-          <CloseBtn onClick={handleExit} src="/assets/btn_close.svg" />
-        </Header>
         <PhotoDiv isMobile={mobile}>
           <LetterImage src={'' + elementImg} onError={handleImageError} />
         </PhotoDiv>


### PR DESCRIPTION
## Description

- [Jira Ticket: RL1M-318](https://relay-letter.atlassian.net/browse/RL1M-318)
- 키보드 노출 시 `height: calc(var(--vh, 1vh) * 100 - ${bottomOffset}px)` 작동 안함 -> 키보드 높이만큼 bottomOffset을 빼서 Content의 높이가 설정되지 않는 문제 계속 발생 (화면 크기만큼 보여짐)

## Changes

- [x] fixed인 header을 Content 밖에 위치 
- [x] `setVh`를 `handleResize` 안에서 추가 호출

### Screenshots
