### PR TITLE
Fix: RL1M-350 250529 5차 QA 마이너 사항들 반영

### DIFF
--- a/src/components/createPage/FinalLetter/EditLetter.tsx
+++ b/src/components/createPage/FinalLetter/EditLetter.tsx
@@ -446,7 +446,7 @@ const InputBox = styled.div`
   gap: 8px;
   justify-content: center;
 
-  width: 224px;
+  width: 100%;
 
   margin-top: 0;
 

--- a/src/components/receivePage/ReceiveLetterContents.tsx
+++ b/src/components/receivePage/ReceiveLetterContents.tsx
@@ -9,6 +9,7 @@ interface LetterContentProps {
   letterContent: LetterDetail;
 }
 
+// FIXME: absolute로 레이아웃되어 있는데 처음부터 다시 해야 할 듯함
 export const ReceiveLetterContents = ({
   letterContent,
 }: LetterContentProps) => {
@@ -60,7 +61,7 @@ const ContentImg = styled.img`
 
 const Content = styled.div`
   position: absolute;
-  top: 65%;
+  top: 67%;
   left: 50%;
 
   display: flex;
@@ -68,7 +69,6 @@ const Content = styled.div`
   flex-direction: column;
 
   align-self: stretch;
-  justify-content: center;
 
   height: 41px;
 


### PR DESCRIPTION
## Description

- [Jira Ticket: RL1M-350](https://relay-letter.atlassian.net/browse/RL1M-350)

## Changes

- [x] 편지 작성 후 수정 시 Input 길이 디자인 오류 수정
- [x] 편지 상세 조회 페이지에서 컨텐츠가 중앙 정렬되는 디자인 오류 수정

## Todo

- [ ] 편지 상세 페이지를 `absolute`가 아닌 `flex`로 쉽고 정밀하게 레이아웃 가능하도록 개선